### PR TITLE
Allow complex versions (e.g. 1.4.0+dev)

### DIFF
--- a/jsonschema_typed/optional_typed_dict.py
+++ b/jsonschema_typed/optional_typed_dict.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Union, Any
+from packaging.version import Version
 
 from mypy.plugin import Plugin, AnalyzeTypeContext
 from mypy.types import TypedDictType
@@ -45,7 +46,7 @@ class OptionalTypedDictPlugin(Plugin):
 
 def plugin(version: str):
     """See `https://mypy.readthedocs.io/en/latest/extending_mypy.html`_."""
-    if float(version) < 0.7:
+    if Version(version) < Version("0.7"):
         warnings.warn(
             "This plugin not tested below mypy 0.710. But you can"
             f" test it and let us know at {ISSUE_URL}."

--- a/jsonschema_typed/plugin.py
+++ b/jsonschema_typed/plugin.py
@@ -6,6 +6,7 @@ import re
 import uuid
 import importlib
 import warnings
+from packaging.version import Version
 from collections import OrderedDict
 from typing import Optional, Callable, Any, Union, List, Set, Dict
 from abc import abstractmethod
@@ -580,7 +581,7 @@ class TypeMaker:
 
 def plugin(version: str):
     """See `https://mypy.readthedocs.io/en/latest/extending_mypy.html`_."""
-    if float(version) < 0.7:
+    if Version(version) < Version("0.7"):
         warnings.warn(
             "This plugin not tested below mypy 0.710. But you can"
             f" test it and let us know at {ISSUE_URL}."


### PR DESCRIPTION
I needed this change to run the plugin.

Fixes https://github.com/inspera/jsonschema-typed/issues/6