### PR TITLE
Allow passing dicts instead of json file locations

### DIFF
--- a/jsonschema_typed/optional_typed_dict.py
+++ b/jsonschema_typed/optional_typed_dict.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Union, Any
+from packaging.version import Version
 
 from mypy.plugin import Plugin, AnalyzeTypeContext
 from mypy.types import TypedDictType
@@ -45,7 +46,7 @@ class OptionalTypedDictPlugin(Plugin):
 
 def plugin(version: str):
     """See `https://mypy.readthedocs.io/en/latest/extending_mypy.html`_."""
-    if float(version) < 0.7:
+    if Version(version) < Version("0.7"):
         warnings.warn(
             "This plugin not tested below mypy 0.710. But you can"
             f" test it and let us know at {ISSUE_URL}."

--- a/jsonschema_typed/plugin.py
+++ b/jsonschema_typed/plugin.py
@@ -528,9 +528,11 @@ class JSONSchemaPlugin(Plugin):
                 if not ctx.type.args:
                     return ctx.type
                 schema_path, *key_path = list(map(self.resolve_var, ctx.type.args))
-
-                schema_path = os.path.abspath(schema_path)
-                schema = self._load_schema(schema_path)
+                if isinstance(schema_path, dict):
+                    schema = schema_path
+                else:
+                    schema_path = os.path.abspath(schema_path)
+                    schema = self._load_schema(schema_path)
 
                 if key_path:
                     schema = self.make_subschema(schema, key_path)

--- a/jsonschema_typed/plugin.py
+++ b/jsonschema_typed/plugin.py
@@ -6,6 +6,7 @@ import re
 import uuid
 import importlib
 import warnings
+from packaging.version import Version
 from collections import OrderedDict
 from typing import Optional, Callable, Any, Union, List, Set, Dict
 from abc import abstractmethod
@@ -580,7 +581,7 @@ class TypeMaker:
 
 def plugin(version: str):
     """See `https://mypy.readthedocs.io/en/latest/extending_mypy.html`_."""
-    if float(version) < 0.7:
+    if Version(version) < Version("0.7"):
         warnings.warn(
             "This plugin not tested below mypy 0.710. But you can"
             f" test it and let us know at {ISSUE_URL}."


### PR DESCRIPTION
We need to pass a previously parsed JSON schema instead of a file location, like this:

```python
v: JSONSchema['var:mymodule.myschema:mySchema']
v = 10  # Type checked
```

This is useful when the schema is already parsed, or if it is stored in a Python file (e.g. for translation).

I suspect this very hacky solution doesn't even work for multiple arguments, but it satisfies our needs, so I can't spend much more time on it. Please feel free to use.

https://github.com/inspera/jsonschema-typed/pull/7 should be merged first.